### PR TITLE
Fix emoji in sector heatmap view

### DIFF
--- a/src/components/SectorHeatmapView.tsx
+++ b/src/components/SectorHeatmapView.tsx
@@ -353,7 +353,7 @@ const SectorHeatmapView: React.FC<SectorHeatmapViewProps> = ({ data: enrichedDat
           </div>
           
           <div>
-            <h4 className="font-semibold text-cyan-300 mb-2">� Peor Sector:</h4>
+            <h4 className="font-semibold text-cyan-300 mb-2">📉 Peor Sector:</h4>
             <p className="text-gray-300">
               <strong>{sectorAnalysis[sectorAnalysis.length - 1]?.name}</strong> con{' '}
               <span className="text-red-400 font-bold">


### PR DESCRIPTION
## Summary
- correct a garbled character in `SectorHeatmapView` so the header shows the right emoji

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6869a9d733dc8333b26d13718668845f