### PR TITLE
Fix heading emoji in sector heatmap

### DIFF
--- a/src/components/SectorHeatmapView.tsx
+++ b/src/components/SectorHeatmapView.tsx
@@ -353,7 +353,7 @@ const SectorHeatmapView: React.FC<SectorHeatmapViewProps> = ({ data: enrichedDat
           </div>
           
           <div>
-            <h4 className="font-semibold text-cyan-300 mb-2">� Peor Sector:</h4>
+            <h4 className="font-semibold text-cyan-300 mb-2">📉 Peor Sector:</h4>
             <p className="text-gray-300">
               <strong>{sectorAnalysis[sectorAnalysis.length - 1]?.name}</strong> con{' '}
               <span className="text-red-400 font-bold">


### PR DESCRIPTION
## Summary
- replace broken character with 📉 in SectorHeatmapView heading

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6869bc5dae50833391cd50ae409381c9